### PR TITLE
fix: can't exec Keyboard func on ios

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,7 @@
             <clobbers target="window.Keyboard"/>
         </js-module>
         <config-file target="config.xml" parent="/*">
-            <feature name="Keyboard">
+            <feature name="IonicKeyboard">
                 <param name="android-package" value="io.ionic.keyboard.IonicKeyboard" onload="true"/>
             </feature>
         </config-file>

--- a/www/android/keyboard.js
+++ b/www/android/keyboard.js
@@ -29,15 +29,15 @@ Keyboard.fireOnShowing = function (height) {
 };
 
 Keyboard.hideKeyboardAccessoryBar = function (hide) {
-    exec(null, null, "Keyboard", "hideKeyboardAccessoryBar", [hide]);
+    exec(null, null, "IonicKeyboard", "hideKeyboardAccessoryBar", [hide]);
 };
 
 Keyboard.close = function () {
-    exec(null, null, "Keyboard", "close", []);
+    exec(null, null, "IonicKeyboard", "close", []);
 };
 
 Keyboard.show = function () {
-    exec(null, null, "Keyboard", "show", []);
+    exec(null, null, "IonicKeyboard", "show", []);
 };
 
 Keyboard.disableScroll = function (disable) {
@@ -45,7 +45,7 @@ Keyboard.disableScroll = function (disable) {
 };
 
 channel.onCordovaReady.subscribe(function () {
-    exec(success, null, 'Keyboard', 'init', []);
+    exec(success, null, 'IonicKeyboard', 'init', []);
 
     function success(msg) {
         var action = msg.charAt(0);

--- a/www/ios/keyboard.js
+++ b/www/ios/keyboard.js
@@ -60,14 +60,14 @@ Keyboard.fireOnResize = function (height, screenHeight, ele) {
 
 Keyboard.hideFormAccessoryBar = function (hide, success) {
     if (hide !== null && hide !== undefined) {
-        exec(success, null, "Keyboard", "hideFormAccessoryBar", [hide]);
+        exec(success, null, "IonicKeyboard", "hideFormAccessoryBar", [hide]);
     } else {
-        exec(success, null, "Keyboard", "hideFormAccessoryBar", []);
+        exec(success, null, "IonicKeyboard", "hideFormAccessoryBar", []);
     }
 };
 
 Keyboard.hide = function () {
-    exec(null, null, "Keyboard", "hide", []);
+    exec(null, null, "IonicKeyboard", "hide", []);
 };
 
 Keyboard.show = function () {


### PR DESCRIPTION
ios feature name is "IonicKeyboard" in plugin.xml, but exec method is call "Keyboard" in ios keyboard.js

So I rename all "Keyboard" to "IonicKeyboard".

Thanks,
Wade Huang