### PR TITLE
fix(android): add hideFormAccessoryBar alias to method hideKeyboardAccessoryBar

### DIFF
--- a/www/android/keyboard.js
+++ b/www/android/keyboard.js
@@ -28,7 +28,7 @@ Keyboard.fireOnShowing = function (height) {
     });
 };
 
-Keyboard.hideKeyboardAccessoryBar = function (hide) {
+Keyboard.hideFormAccessoryBar = Keyboard.hideKeyboardAccessoryBar = function (hide) {
     exec(null, null, "Keyboard", "hideKeyboardAccessoryBar", [hide]);
 };
 


### PR DESCRIPTION
I added an alias of hideFormAccessoryBar to Android JavaScript method hideKeyboardAccessoryBar to keep the API consistent between platforms and to match the README.