### PR TITLE
Android Keyboard hide method name now matches what's in documentation

### DIFF
--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -30,7 +30,7 @@ public class IonicKeyboard extends CordovaPlugin {
     }
 
     public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
-        if ("close".equals(action)) {
+        if ("hide".equals(action)) {
             cordova.getThreadPool().execute(new Runnable() {
                 public void run() {
                     //http://stackoverflow.com/a/7696791/1091751

--- a/www/android/keyboard.js
+++ b/www/android/keyboard.js
@@ -32,8 +32,8 @@ Keyboard.hideKeyboardAccessoryBar = function (hide) {
     exec(null, null, "Keyboard", "hideKeyboardAccessoryBar", [hide]);
 };
 
-Keyboard.close = function () {
-    exec(null, null, "Keyboard", "close", []);
+Keyboard.hide = function () {
+    exec(null, null, "Keyboard", "hide", []);
 };
 
 Keyboard.show = function () {


### PR DESCRIPTION
Both Android and iOS now use `Keyboard.hide()` to hide keyboard.
Before hiding on iOS was done with `Keyboard.hide()` and Android was done with `Keyboard.close()`