### PR TITLE
Fix for issue #20

### DIFF
--- a/www/android/keyboard.js
+++ b/www/android/keyboard.js
@@ -11,11 +11,21 @@ Keyboard.fireOnShow = function (height) {
     cordova.fireWindowEvent('keyboardDidShow', {
         'keyboardHeight': height
     });
+
+    // To support the keyboardAttach directive listening events
+    // inside Ionic's main bundle
+    cordova.fireWindowEvent('native.keyboardshow', {
+        'keyboardHeight': height
+    });
 };
 
 Keyboard.fireOnHide = function () {
     Keyboard.isVisible = false;
     cordova.fireWindowEvent('keyboardDidHide');
+
+    // To support the keyboardAttach directive listening events
+    // inside Ionic's main bundle
+    cordova.fireWindowEvent('native.keyboardhide');
 };
 
 Keyboard.fireOnHiding = function () {

--- a/www/ios/keyboard.js
+++ b/www/ios/keyboard.js
@@ -30,11 +30,21 @@ Keyboard.fireOnShow = function (height) {
     cordova.fireWindowEvent('keyboardDidShow', {
         'keyboardHeight': height
     });
+
+    // To support the keyboardAttach directive listening events
+    // inside Ionic's main bundle
+    cordova.fireWindowEvent('native.keyboardshow', {
+        'keyboardHeight': height
+    });
 };
 
 Keyboard.fireOnHide = function () {
     Keyboard.isVisible = false;
     cordova.fireWindowEvent('keyboardDidHide');
+
+    // To support the keyboardAttach directive listening events
+    // inside Ionic's main bundle
+    cordova.fireWindowEvent('native.keyboardhide');
 };
 
 Keyboard.fireOnHiding = function () {


### PR DESCRIPTION
Copied event emits from deprecated ionic keyboard plugin in order to regain keyboardAttach directive usage.