### PR TITLE
Avoid duplicate hide event when user changes field

### DIFF
--- a/src/ios/CDVIonicKeyboard.m
+++ b/src/ios/CDVIonicKeyboard.m
@@ -44,6 +44,8 @@ typedef enum : NSUInteger {
 
 @implementation CDVIonicKeyboard
 
+NSTimer *hideTimer;
+
 - (id)settingForKey:(NSString *)key
 {
     return [self.commandDelegate.settings objectForKey:[key lowercaseString]];
@@ -117,11 +119,18 @@ typedef enum : NSUInteger {
         [self setKeyboardHeight:0 delay:0.01];
         [self resetScrollView];
     }
+    hideTimer = [NSTimer scheduledTimerWithTimeInterval:0 target:self selector:@selector(fireOnHiding) userInfo:nil repeats:NO];
+}
+
+- (void)fireOnHiding {
     [self.commandDelegate evalJs:@"Keyboard.fireOnHiding();"];
 }
 
 - (void)onKeyboardWillShow:(NSNotification *)note
 {
+    if (hideTimer != nil) {
+        [hideTimer invalidate];
+    }
     CGRect rect = [[note.userInfo valueForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue];
     double height = rect.size.height;
 


### PR DESCRIPTION
iOS keyboard always calls willHide, even when user changes the input field and there is no visible disappear/appear animations.

This PR uses a timer that is disabled if willShow is called right after willHide, so it doesn't send the event. 