### PR TITLE
Delay resize until keyboard animation finish

### DIFF
--- a/src/ios/CDVIonicKeyboard.m
+++ b/src/ios/CDVIonicKeyboard.m
@@ -136,7 +136,7 @@ NSTimer *hideTimer;
 
     if (self.isWK) {
         double duration = [[note.userInfo valueForKey:UIKeyboardAnimationDurationUserInfoKey] doubleValue];
-        [self setKeyboardHeight:height delay:duration/2.0];
+        [self setKeyboardHeight:height delay:duration+0.2];
         [self resetScrollView];
     }
 


### PR DESCRIPTION
to avoid the viewcontroller view being displayed while the resize is done